### PR TITLE
go-tools: 4046-act-panics-in-decryptopenxprice-part-2

### DIFF
--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -17,7 +17,7 @@ const (
 func DecryptHmacXorWithIntegrity(message, encryptKey, integrityKey []byte) ([]byte, error) {
 	size := len(message)
 	if size < minimalMessageSize {
-		return nil, fmt.Errorf("message length to short(<%d), message: %v, message-size: %d", minimalMessageSize, message, len(message))
+		return nil, fmt.Errorf("message length too short(<%d), message: %v, length: %d", minimalMessageSize, message, len(message))
 	}
 
 	initializationVector := message[0:initializationVectorSize]
@@ -32,7 +32,7 @@ func DecryptHmacXorWithIntegrity(message, encryptKey, integrityKey []byte) ([]by
 
 	pad := mac.Sum(nil)
 	if len(pad) < cipherTextSize {
-		return nil, fmt.Errorf("pad length to short, pad: %v, pad-size: %d, message: %v, cipher-text-size: %d", pad, len(pad), message, len(cipherText))
+		return nil, fmt.Errorf("pad length too short, pad: %v, pad-length: %d, message: %v, cipher-text-length: %d", pad, len(pad), message, len(cipherText))
 	}
 
 	unciphered := make([]byte, cipherTextSize)

--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -82,7 +82,7 @@ func cryptHmacXorWithIntegrity(message []byte, h func() hash.Hash, encryptKey []
 
 	pad := padMac.Sum(nil)
 	if len(pad) < len(message) {
-		return nil, fmt.Errorf("pad length to short, pad: %v, pad-size: %d, message: %v, message-text-size: %d", pad, len(pad), message, len(message))
+		return nil, fmt.Errorf("pad length too short, pad: %v, pad-length: %d, message: %v, message-text-length: %d", pad, len(pad), message, len(message))
 	}
 
 	ciphered := make([]byte, len(message))

--- a/crypt/crypt.go
+++ b/crypt/crypt.go
@@ -11,10 +11,15 @@ import (
 const (
 	initializationVectorSize = 16
 	integritySignatureSize   = 4
+	minimalMessageSize       = initializationVectorSize + integritySignatureSize
 )
 
 func DecryptHmacXorWithIntegrity(message, encryptKey, integrityKey []byte) ([]byte, error) {
 	size := len(message)
+	if size < minimalMessageSize {
+		return nil, fmt.Errorf("message length to short(<%d), message: %v, message-size: %d", minimalMessageSize, message, len(message))
+	}
+
 	initializationVector := message[0:initializationVectorSize]
 	cipherText := message[initializationVectorSize : size-integritySignatureSize]
 	cipherTextSize := len(cipherText)

--- a/crypt/crypt_test.go
+++ b/crypt/crypt_test.go
@@ -68,7 +68,7 @@ func TestDecryptHmacXorWithIntegrity(t *testing.T) {
 	})
 
 	t.Run("check message length", func(t *testing.T) {
-		t.Run("message to short", func(t *testing.T) {
+		t.Run("message too short", func(t *testing.T) {
 			cryptMsg := []byte{0, 0, 0, 24, 255, 22, 1, 120}
 			require.True(t, len(cryptMsg) < minimalMessageSize)
 

--- a/crypt/crypt_test.go
+++ b/crypt/crypt_test.go
@@ -85,7 +85,7 @@ func TestDecryptHmacXorWithIntegrity(t *testing.T) {
 
 			result, err := DecryptHmacXorWithIntegrity(cryptMsg, testEncryptionKeys, testIntegrityKeys)
 			require.NoError(t, err)
-			assert.EqualValues(t, bytes, result)
+			assert.Empty(t, result)
 		})
 	})
 

--- a/crypt/crypt_test.go
+++ b/crypt/crypt_test.go
@@ -63,7 +63,7 @@ func TestDecryptHmacXorWithIntegrity(t *testing.T) {
 
 			_, err = DecryptHmacXorWithIntegrity(cryptMsg, testEncryptionKeys, testIntegrityKeys)
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "pad length to short") // the error is not because of the wrong hash function
+			assert.Contains(t, err.Error(), "pad length too short") // the error is not because of the wrong hash function
 		})
 	})
 
@@ -74,7 +74,7 @@ func TestDecryptHmacXorWithIntegrity(t *testing.T) {
 
 			_, err := DecryptHmacXorWithIntegrity(cryptMsg, testEncryptionKeys, testIntegrityKeys)
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "message length to short")
+			assert.Contains(t, err.Error(), "message length too short")
 		})
 
 		t.Run("minimal message length", func(t *testing.T) {


### PR DESCRIPTION
the message length is too short, so I insert a length check.
The travis build fix is in the other pr: https://github.com/remerge/go-tools/tree/fix_travis_build

[Act panics in DecryptOpenXPrice (part 2)](https://trello.com/c/Se7no4WP/4046-act-panics-in-decryptopenxprice-part-2)