### PR TITLE
convert slices with number types to each other

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/remerge/go-tools
 
+require github.com/stretchr/testify v1.3.0
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/stretchr/testify v1.3.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 )
 
-go 1.13
+go 1.20

--- a/typconv/slices.go
+++ b/typconv/slices.go
@@ -1,0 +1,17 @@
+package typconv
+
+type ConvertableNumber interface {
+	int | int32 | int64 | uint32 | uint64 | float32 | float64
+}
+
+func SliceToSlice[T, U ConvertableNumber](v []T) []U {
+	if len(v) == 0 {
+		return nil
+	}
+
+	out := make([]U, len(v))
+	for i, vv := range v {
+		out[i] = U(vv)
+	}
+	return out
+}


### PR DESCRIPTION
This change adds `SliceToSlice` method which allows to convert slices with different numeric types to each other.